### PR TITLE
Add structured logging to service implementations

### DIFF
--- a/src/main/java/task/healthyhabits/services/guide/GuideServiceImplementation.java
+++ b/src/main/java/task/healthyhabits/services/guide/GuideServiceImplementation.java
@@ -1,6 +1,8 @@
 package task.healthyhabits.services.guide;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +31,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GuideServiceImplementation implements GuideService {
 
+    private static final Logger logger = LogManager.getLogger(GuideServiceImplementation.class);
     private final GuideRepository guideRepository;
     private final HabitRepository habitRepository;
     private final UserRepository userRepository;
@@ -37,8 +40,16 @@ public class GuideServiceImplementation implements GuideService {
     @Override
     @Transactional(readOnly = true)
     public Page<GuideDTO> list(Pageable pageable) {
-        return guideRepository.findAll(pageable)
-                .map(entity -> mapperFactory.createMapper(Guide.class, GuideDTO.class).convertToDTO(entity));
+        logger.info("Listing guides with pageable {}", pageable);
+        try {
+            Page<GuideDTO> guides = guideRepository.findAll(pageable)
+                    .map(entity -> mapperFactory.createMapper(Guide.class, GuideDTO.class).convertToDTO(entity));
+            logger.info("Listed {} guides", guides.getNumberOfElements());
+            return guides;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error listing guides with pageable {}", pageable, ex);
+            throw ex;
+        }
     }
 
     @Override
@@ -67,7 +78,10 @@ public class GuideServiceImplementation implements GuideService {
             return paginate(filtered, pageable);
         }
         User user = userRepository.findById(forUserId)
-                .orElseThrow(() -> new NoSuchElementException("User not found"));
+                .orElseThrow(() -> {
+                    logger.warn("User {} not found for recommended guides", forUserId);
+                    return new NoSuchElementException("User not found");
+                });
         Set<Long> favIds = user.getFavoriteHabits() == null
                 ? Set.of()
                 : user.getFavoriteHabits().stream().map(Habit::getId).collect(Collectors.toSet());
@@ -85,39 +99,60 @@ public class GuideServiceImplementation implements GuideService {
     @Override
     @Transactional
     public GuideOutputDTO create(GuideInputDTO input) {
-        InputOutputMapper<GuideInputDTO, Guide, GuideOutputDTO> io = mapperFactory
-                .createInputOutputMapper(GuideInputDTO.class, Guide.class, GuideOutputDTO.class);
-        Guide guide = io.convertFromInput(input);
-        List<Habit> rec = (input.getRecommendedHabitIds() == null || input.getRecommendedHabitIds().isEmpty())
-                ? new ArrayList<>()
-                : habitRepository.findAllById(input.getRecommendedHabitIds());
-        guide.setRecommendedFor(rec);
-        guide = guideRepository.save(guide);
-        return io.convertToOutput(guide);
+        logger.info("Creating guide with title {}", input.getTitle());
+        try {
+            InputOutputMapper<GuideInputDTO, Guide, GuideOutputDTO> io = mapperFactory
+                    .createInputOutputMapper(GuideInputDTO.class, Guide.class, GuideOutputDTO.class);
+            Guide guide = io.convertFromInput(input);
+            List<Habit> rec = (input.getRecommendedHabitIds() == null || input.getRecommendedHabitIds().isEmpty())
+                    ? new ArrayList<>()
+                    : habitRepository.findAllById(input.getRecommendedHabitIds());
+            guide.setRecommendedFor(rec);
+            guide = guideRepository.save(guide);
+            GuideOutputDTO output = io.convertToOutput(guide);
+            logger.info("Created guide {} with title {}", guide.getId(), guide.getTitle());
+            return output;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error creating guide with title {}", input.getTitle(), ex);
+            throw ex;
+        }
     }
 
     @Override
     @Transactional
     public GuideOutputDTO update(Long id, GuideInputDTO input) {
-        InputOutputMapper<GuideInputDTO, Guide, GuideOutputDTO> io = mapperFactory
-                .createInputOutputMapper(GuideInputDTO.class, Guide.class, GuideOutputDTO.class);
-        Guide guide = guideRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("Guide not found"));
-        if (input.getTitle() != null)
-            guide.setTitle(input.getTitle());
-        if (input.getContent() != null)
-            guide.setContent(input.getContent());
-        if (input.getCategory() != null)
-            guide.setCategory(input.getCategory());
-        if (input.getObjective() != null)
-            guide.setObjective(input.getObjective());
-        if (input.getRecommendedHabitIds() != null) {
-            List<Long> ids = input.getRecommendedHabitIds();
-            List<Habit> rec = ids.isEmpty() ? new ArrayList<>() : habitRepository.findAllById(ids);
-            guide.setRecommendedFor(rec);
+        logger.info("Updating guide {} with input {}", id, input);
+        try {
+            InputOutputMapper<GuideInputDTO, Guide, GuideOutputDTO> io = mapperFactory
+                    .createInputOutputMapper(GuideInputDTO.class, Guide.class, GuideOutputDTO.class);
+            Guide guide = guideRepository.findById(id)
+                    .orElseThrow(() -> {
+                        logger.warn("Guide {} not found for update", id);
+                        return new NoSuchElementException("Guide not found");
+                    });
+            if (input.getTitle() != null)
+                guide.setTitle(input.getTitle());
+            if (input.getContent() != null)
+                guide.setContent(input.getContent());
+            if (input.getCategory() != null)
+                guide.setCategory(input.getCategory());
+            if (input.getObjective() != null)
+                guide.setObjective(input.getObjective());
+            if (input.getRecommendedHabitIds() != null) {
+                List<Long> ids = input.getRecommendedHabitIds();
+                List<Habit> rec = ids.isEmpty() ? new ArrayList<>() : habitRepository.findAllById(ids);
+                guide.setRecommendedFor(rec);
+            }
+            guide = guideRepository.save(guide);
+            GuideOutputDTO output = io.convertToOutput(guide);
+            logger.info("Updated guide {} successfully", id);
+            return output;
+        } catch (NoSuchElementException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error updating guide {}", id, ex);
+            throw ex;
         }
-        guide = guideRepository.save(guide);
-        return io.convertToOutput(guide);
     }
 
     private static <T> Page<T> paginate(List<T> all, Pageable pageable) {
@@ -132,9 +167,18 @@ public class GuideServiceImplementation implements GuideService {
     @Override
     @Transactional
     public boolean delete(Long id) {
-        if (!guideRepository.existsById(id))
-            return false;
-        guideRepository.deleteById(id);
-        return true;
+        logger.info("Deleting guide {}", id);
+        try {
+            if (!guideRepository.existsById(id)) {
+                logger.warn("Guide {} not found for deletion", id);
+                return false;
+            }
+            guideRepository.deleteById(id);
+            logger.info("Deleted guide {}", id);
+            return true;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error deleting guide {}", id, ex);
+            throw ex;
+        }
     }
 }

--- a/src/main/java/task/healthyhabits/services/reminder/ReminderServiceImplementation.java
+++ b/src/main/java/task/healthyhabits/services/reminder/ReminderServiceImplementation.java
@@ -1,6 +1,8 @@
 package task.healthyhabits.services.reminder;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +29,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ReminderServiceImplementation implements ReminderService {
 
+    private static final Logger logger = LogManager.getLogger(ReminderServiceImplementation.class);
     private final ReminderRepository reminderRepository;
     private final UserRepository userRepository;
     private final HabitRepository habitRepository;
@@ -35,8 +38,16 @@ public class ReminderServiceImplementation implements ReminderService {
     @Override
     @Transactional(readOnly = true)
     public Page<ReminderDTO> list(Pageable pageable) {
-        return reminderRepository.findAll(pageable)
-                .map(entity -> mapperFactory.createMapper(Reminder.class, ReminderDTO.class).convertToDTO(entity));
+        logger.info("Listing reminders with pageable {}", pageable);
+        try {
+            Page<ReminderDTO> reminders = reminderRepository.findAll(pageable)
+                    .map(entity -> mapperFactory.createMapper(Reminder.class, ReminderDTO.class).convertToDTO(entity));
+            logger.info("Listed {} reminders", reminders.getNumberOfElements());
+            return reminders;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error listing reminders with pageable {}", pageable, ex);
+            throw ex;
+        }
     }
 
     @Override
@@ -60,50 +71,95 @@ public class ReminderServiceImplementation implements ReminderService {
     @Override
     @Transactional
     public ReminderOutputDTO create(ReminderInputDTO input) {
-        InputOutputMapper<ReminderInputDTO, Reminder, ReminderOutputDTO> io =
-                mapperFactory.createInputOutputMapper(ReminderInputDTO.class, Reminder.class, ReminderOutputDTO.class);
-        User user = userRepository.findById(input.getUserId())
-                .orElseThrow(() -> new NoSuchElementException("User not found"));
-        Habit habit = habitRepository.findById(input.getHabitId())
-                .orElseThrow(() -> new NoSuchElementException("Habit not found"));
-        Reminder reminder = new Reminder();
-        reminder.setUser(user);
-        reminder.setHabit(habit);
-        reminder.setTime(input.getTime());
-        reminder.setFrequency(input.getFrequency());
-        reminder = reminderRepository.save(reminder);
-        return io.convertToOutput(reminder);
+        logger.info("Creating reminder for user {} and habit {}", input.getUserId(), input.getHabitId());
+        try {
+            InputOutputMapper<ReminderInputDTO, Reminder, ReminderOutputDTO> io =
+                    mapperFactory.createInputOutputMapper(ReminderInputDTO.class, Reminder.class, ReminderOutputDTO.class);
+            User user = userRepository.findById(input.getUserId())
+                    .orElseThrow(() -> {
+                        logger.warn("User {} not found for reminder creation", input.getUserId());
+                        return new NoSuchElementException("User not found");
+                    });
+            Habit habit = habitRepository.findById(input.getHabitId())
+                    .orElseThrow(() -> {
+                        logger.warn("Habit {} not found for reminder creation", input.getHabitId());
+                        return new NoSuchElementException("Habit not found");
+                    });
+            Reminder reminder = new Reminder();
+            reminder.setUser(user);
+            reminder.setHabit(habit);
+            reminder.setTime(input.getTime());
+            reminder.setFrequency(input.getFrequency());
+            reminder = reminderRepository.save(reminder);
+            ReminderOutputDTO output = io.convertToOutput(reminder);
+            logger.info("Created reminder {} for user {}", reminder.getId(), user.getId());
+            return output;
+        } catch (NoSuchElementException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error creating reminder for user {}", input.getUserId(), ex);
+            throw ex;
+        }
     }
 
     @Override
     @Transactional
     public ReminderOutputDTO update(Long id, ReminderInputDTO input) {
-        InputOutputMapper<ReminderInputDTO, Reminder, ReminderOutputDTO> io =
-                mapperFactory.createInputOutputMapper(ReminderInputDTO.class, Reminder.class, ReminderOutputDTO.class);
-        Reminder reminder = reminderRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("Reminder not found"));
-        if (input.getUserId() != null) {
-            User user = userRepository.findById(input.getUserId())
-                    .orElseThrow(() -> new NoSuchElementException("User not found"));
-            reminder.setUser(user);
+        logger.info("Updating reminder {} with input {}", id, input);
+        try {
+            InputOutputMapper<ReminderInputDTO, Reminder, ReminderOutputDTO> io =
+                    mapperFactory.createInputOutputMapper(ReminderInputDTO.class, Reminder.class, ReminderOutputDTO.class);
+            Reminder reminder = reminderRepository.findById(id)
+                    .orElseThrow(() -> {
+                        logger.warn("Reminder {} not found for update", id);
+                        return new NoSuchElementException("Reminder not found");
+                    });
+            if (input.getUserId() != null) {
+                User user = userRepository.findById(input.getUserId())
+                        .orElseThrow(() -> {
+                            logger.warn("User {} not found for reminder update", input.getUserId());
+                            return new NoSuchElementException("User not found");
+                        });
+                reminder.setUser(user);
+            }
+            if (input.getHabitId() != null) {
+                Habit habit = habitRepository.findById(input.getHabitId())
+                        .orElseThrow(() -> {
+                            logger.warn("Habit {} not found for reminder update", input.getHabitId());
+                            return new NoSuchElementException("Habit not found");
+                        });
+                reminder.setHabit(habit);
+            }
+            if (input.getTime() != null) reminder.setTime(input.getTime());
+            if (input.getFrequency() != null) reminder.setFrequency(input.getFrequency());
+            reminder = reminderRepository.save(reminder);
+            ReminderOutputDTO output = io.convertToOutput(reminder);
+            logger.info("Updated reminder {} successfully", id);
+            return output;
+        } catch (NoSuchElementException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error updating reminder {}", id, ex);
+            throw ex;
         }
-        if (input.getHabitId() != null) {
-            Habit habit = habitRepository.findById(input.getHabitId())
-                    .orElseThrow(() -> new NoSuchElementException("Habit not found"));
-            reminder.setHabit(habit);
-        }
-        if (input.getTime() != null) reminder.setTime(input.getTime());
-        if (input.getFrequency() != null) reminder.setFrequency(input.getFrequency());
-        reminder = reminderRepository.save(reminder);
-        return io.convertToOutput(reminder);
     }
 
     @Override
     @Transactional
     public boolean delete(Long id) {
-        if (!reminderRepository.existsById(id)) return false;
-        reminderRepository.deleteById(id);
-        return true;
+        logger.info("Deleting reminder {}", id);
+        try {
+            if (!reminderRepository.existsById(id)) {
+                logger.warn("Reminder {} not found for deletion", id);
+                return false;
+            }
+            reminderRepository.deleteById(id);
+            logger.info("Deleted reminder {}", id);
+            return true;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error deleting reminder {}", id, ex);
+            throw ex;
+        }
     }
 
     private static <T> Page<T> paginate(List<T> all, Pageable pageable) {

--- a/src/main/java/task/healthyhabits/services/role/RoleServiceImplementation.java
+++ b/src/main/java/task/healthyhabits/services/role/RoleServiceImplementation.java
@@ -1,6 +1,8 @@
 package task.healthyhabits.services.role;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,14 +23,23 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class RoleServiceImplementation implements RoleService {
 
+    private static final Logger logger = LogManager.getLogger(RoleServiceImplementation.class);
     private final RoleRepository roleRepository;
     private final GenericMapperFactory mapperFactory;
 
     @Override
     @Transactional(readOnly = true)
     public Page<RoleDTO> list(Pageable pageable) {
-        return roleRepository.findAll(pageable)
-                .map(entity -> mapperFactory.createMapper(Role.class, RoleDTO.class).convertToDTO(entity));
+        logger.info("Listing roles with pageable {}", pageable);
+        try {
+            Page<RoleDTO> roles = roleRepository.findAll(pageable)
+                    .map(entity -> mapperFactory.createMapper(Role.class, RoleDTO.class).convertToDTO(entity));
+            logger.info("Listed {} roles", roles.getNumberOfElements());
+            return roles;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error listing roles with pageable {}", pageable, ex);
+            throw ex;
+        }
     }
 
     @Override
@@ -45,46 +56,79 @@ public class RoleServiceImplementation implements RoleService {
         Permission perm = input.getPermission();
         Optional<Role> duplicate = roleRepository.findByPermission(perm);
         if (duplicate.isPresent()) {
+            logger.warn("Permission {} already used by another role", perm);
             throw new IllegalArgumentException("Permission already used by another role");
         }
-        InputOutputMapper<RoleInputDTO, Role, RoleOutputDTO> io =
-                mapperFactory.createInputOutputMapper(RoleInputDTO.class, Role.class, RoleOutputDTO.class);
-        Role role = io.convertFromInput(input);
-        if (role.getName() == null || role.getName().isBlank()) {
-            role.setName(perm.name());
+        logger.info("Creating role with permission {}", perm);
+        try {
+            InputOutputMapper<RoleInputDTO, Role, RoleOutputDTO> io =
+                    mapperFactory.createInputOutputMapper(RoleInputDTO.class, Role.class, RoleOutputDTO.class);
+            Role role = io.convertFromInput(input);
+            if (role.getName() == null || role.getName().isBlank()) {
+                role.setName(perm.name());
+            }
+            role = roleRepository.save(role);
+            RoleOutputDTO output = io.convertToOutput(role);
+            logger.info("Created role {} with permission {}", role.getId(), perm);
+            return output;
+        } catch (IllegalArgumentException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error creating role with permission {}", perm, ex);
+            throw ex;
         }
-        role = roleRepository.save(role);
-        return io.convertToOutput(role);
     }
 
     @Override
     @Transactional
     public RoleOutputDTO update(Long id, RoleInputDTO input) {
-        InputOutputMapper<RoleInputDTO, Role, RoleOutputDTO> io =
-                mapperFactory.createInputOutputMapper(RoleInputDTO.class, Role.class, RoleOutputDTO.class);
-        Role role = roleRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("Role not found"));
-        if (input.getPermission() != null && input.getPermission() != role.getPermission()) {
-            Optional<Role> exists = roleRepository.findByPermission(input.getPermission());
-            if (exists.isPresent() && !exists.get().getId().equals(id)) {
-                throw new IllegalArgumentException("Permission already used by another role");
+        logger.info("Updating role {} with input {}", id, input);
+        try {
+            InputOutputMapper<RoleInputDTO, Role, RoleOutputDTO> io =
+                    mapperFactory.createInputOutputMapper(RoleInputDTO.class, Role.class, RoleOutputDTO.class);
+            Role role = roleRepository.findById(id)
+                    .orElseThrow(() -> {
+                        logger.warn("Role {} not found for update", id);
+                        return new NoSuchElementException("Role not found");
+                    });
+            if (input.getPermission() != null && input.getPermission() != role.getPermission()) {
+                Optional<Role> exists = roleRepository.findByPermission(input.getPermission());
+                if (exists.isPresent() && !exists.get().getId().equals(id)) {
+                    logger.warn("Permission {} already used by role {}", input.getPermission(), exists.get().getId());
+                    throw new IllegalArgumentException("Permission already used by another role");
+                }
+                role.setPermission(input.getPermission());
             }
-            role.setPermission(input.getPermission());
+            if (input.getName() != null) {
+                role.setName(input.getName());
+            }
+            role = roleRepository.save(role);
+            RoleOutputDTO output = io.convertToOutput(role);
+            logger.info("Updated role {} successfully", id);
+            return output;
+        } catch (IllegalArgumentException | NoSuchElementException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error updating role {}", id, ex);
+            throw ex;
         }
-        if (input.getName() != null) {
-            role.setName(input.getName());
-        }
-        role = roleRepository.save(role);
-        return io.convertToOutput(role);
     }
 
     @Override
     @Transactional
     public boolean delete(Long id) {
-        if (!roleRepository.existsById(id)) {
-            return false;
+        logger.info("Deleting role {}", id);
+        try {
+            if (!roleRepository.existsById(id)) {
+                logger.warn("Role {} not found for deletion", id);
+                return false;
+            }
+            roleRepository.deleteById(id);
+            logger.info("Deleted role {}", id);
+            return true;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error deleting role {}", id, ex);
+            throw ex;
         }
-        roleRepository.deleteById(id);
-        return true;
     }
 }

--- a/src/main/java/task/healthyhabits/services/routine/RoutineServiceImplementation.java
+++ b/src/main/java/task/healthyhabits/services/routine/RoutineServiceImplementation.java
@@ -1,6 +1,8 @@
 package task.healthyhabits.services.routine;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,6 +30,7 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 public class RoutineServiceImplementation implements RoutineService {
 
+    private static final Logger logger = LogManager.getLogger(RoutineServiceImplementation.class);
     private final RoutineRepository routineRepository;
     private final RoutineActivityRepository routineActivityRepository;
     private final UserRepository userRepository;
@@ -37,8 +40,16 @@ public class RoutineServiceImplementation implements RoutineService {
     @Override
     @Transactional(readOnly = true)
     public Page<RoutineDTO> list(Pageable pageable) {
-        return routineRepository.findAll(pageable)
-                .map(entity -> mapperFactory.createMapper(Routine.class, RoutineDTO.class).convertToDTO(entity));
+        logger.info("Listing routines with pageable {}", pageable);
+        try {
+            Page<RoutineDTO> routines = routineRepository.findAll(pageable)
+                    .map(entity -> mapperFactory.createMapper(Routine.class, RoutineDTO.class).convertToDTO(entity));
+            logger.info("Listed {} routines", routines.getNumberOfElements());
+            return routines;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error listing routines with pageable {}", pageable, ex);
+            throw ex;
+        }
     }
 
     @Override
@@ -65,85 +76,130 @@ public class RoutineServiceImplementation implements RoutineService {
     @Override
     @Transactional
     public RoutineOutputDTO create(RoutineInputDTO input) {
-        InputOutputMapper<RoutineInputDTO, Routine, RoutineOutputDTO> io =
-                mapperFactory.createInputOutputMapper(RoutineInputDTO.class, Routine.class, RoutineOutputDTO.class);
-        User user = userRepository.findById(input.getUserId())
-                .orElseThrow(() -> new NoSuchElementException("User not found"));
-        Routine routine = new Routine();
-        routine.setTitle(input.getTitle());
-        routine.setDescription(input.getDescription());
-        routine.setDaysOfWeek(input.getDaysOfWeek());
-        routine.setTags(input.getTags() == null ? new ArrayList<>() : input.getTags());
-        routine.setUser(user);
-        routine.setActivities(new ArrayList<>());
-        routine = routineRepository.save(routine);
-        if (input.getActivityInputs() != null) {
-            List<RoutineActivity> acts = new ArrayList<>();
-            for (RoutineActivityInputDTO ai : input.getActivityInputs()) {
-                Habit habit = habitRepository.findById(ai.getHabitId())
-                        .orElseThrow(() -> new NoSuchElementException("Habit not found"));
-                RoutineActivity ra = new RoutineActivity();
-                ra.setHabit(habit);
-                ra.setDuration(ai.getDuration());
-                ra.setTargetTime(ai.getTargetTime() != null ? ai.getTargetTime() : 0);
-                ra.setNotes(ai.getNotes());
-                ra.setRoutine(routine);
-                acts.add(ra);
+        logger.info("Creating routine with input {}", input);
+        try {
+            InputOutputMapper<RoutineInputDTO, Routine, RoutineOutputDTO> io =
+                    mapperFactory.createInputOutputMapper(RoutineInputDTO.class, Routine.class, RoutineOutputDTO.class);
+            User user = userRepository.findById(input.getUserId())
+                    .orElseThrow(() -> {
+                        logger.warn("User {} not found for routine creation", input.getUserId());
+                        return new NoSuchElementException("User not found");
+                    });
+            Routine routine = new Routine();
+            routine.setTitle(input.getTitle());
+            routine.setDescription(input.getDescription());
+            routine.setDaysOfWeek(input.getDaysOfWeek());
+            routine.setTags(input.getTags() == null ? new ArrayList<>() : input.getTags());
+            routine.setUser(user);
+            routine.setActivities(new ArrayList<>());
+            routine = routineRepository.save(routine);
+            if (input.getActivityInputs() != null) {
+                List<RoutineActivity> acts = new ArrayList<>();
+                for (RoutineActivityInputDTO ai : input.getActivityInputs()) {
+                    Habit habit = habitRepository.findById(ai.getHabitId())
+                            .orElseThrow(() -> {
+                                logger.warn("Habit {} not found for routine creation", ai.getHabitId());
+                                return new NoSuchElementException("Habit not found");
+                            });
+                    RoutineActivity ra = new RoutineActivity();
+                    ra.setHabit(habit);
+                    ra.setDuration(ai.getDuration());
+                    ra.setTargetTime(ai.getTargetTime() != null ? ai.getTargetTime() : 0);
+                    ra.setNotes(ai.getNotes());
+                    ra.setRoutine(routine);
+                    acts.add(ra);
+                }
+                routineActivityRepository.saveAll(acts);
+                routine.setActivities(acts);
             }
-            routineActivityRepository.saveAll(acts);
-            routine.setActivities(acts);
+            RoutineOutputDTO output = io.convertToOutput(routine);
+            logger.info("Created routine {} for user {}", routine.getId(), user.getId());
+            return output;
+        } catch (NoSuchElementException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error creating routine with input {}", input, ex);
+            throw ex;
         }
-        return io.convertToOutput(routine);
     }
 
     @Override
     @Transactional
     public RoutineOutputDTO update(Long id, RoutineInputDTO input) {
-        InputOutputMapper<RoutineInputDTO, Routine, RoutineOutputDTO> io =
-                mapperFactory.createInputOutputMapper(RoutineInputDTO.class, Routine.class, RoutineOutputDTO.class);
-        Routine routine = routineRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("Routine not found"));
-        User user = userRepository.findById(input.getUserId())
-                .orElseThrow(() -> new NoSuchElementException("User not found"));
-        if (input.getTitle() != null) routine.setTitle(input.getTitle());
-        if (input.getDescription() != null) routine.setDescription(input.getDescription());
-        if (input.getTags() != null) routine.setTags(input.getTags());
-        if (input.getDaysOfWeek() != null) routine.setDaysOfWeek(input.getDaysOfWeek());
-        routine.setUser(user);
-        if (routine.getActivities() != null && !routine.getActivities().isEmpty()) {
-            routineActivityRepository.deleteAll(new ArrayList<>(routine.getActivities()));
-            routine.getActivities().clear();
-        }
-        if (input.getActivityInputs() != null) {
-            List<RoutineActivity> acts = new ArrayList<>();
-            for (RoutineActivityInputDTO ai : input.getActivityInputs()) {
-                Habit habit = habitRepository.findById(ai.getHabitId())
-                        .orElseThrow(() -> new NoSuchElementException("Habit not found"));
-                RoutineActivity ra = new RoutineActivity();
-                ra.setHabit(habit);
-                ra.setDuration(ai.getDuration());
-                ra.setTargetTime(ai.getTargetTime() != null ? ai.getTargetTime() : 0);
-                ra.setNotes(ai.getNotes());
-                ra.setRoutine(routine);
-                acts.add(ra);
+        logger.info("Updating routine {} with input {}", id, input);
+        try {
+            InputOutputMapper<RoutineInputDTO, Routine, RoutineOutputDTO> io =
+                    mapperFactory.createInputOutputMapper(RoutineInputDTO.class, Routine.class, RoutineOutputDTO.class);
+            Routine routine = routineRepository.findById(id)
+                    .orElseThrow(() -> {
+                        logger.warn("Routine {} not found for update", id);
+                        return new NoSuchElementException("Routine not found");
+                    });
+            User user = userRepository.findById(input.getUserId())
+                    .orElseThrow(() -> {
+                        logger.warn("User {} not found for routine update", input.getUserId());
+                        return new NoSuchElementException("User not found");
+                    });
+            if (input.getTitle() != null) routine.setTitle(input.getTitle());
+            if (input.getDescription() != null) routine.setDescription(input.getDescription());
+            if (input.getTags() != null) routine.setTags(input.getTags());
+            if (input.getDaysOfWeek() != null) routine.setDaysOfWeek(input.getDaysOfWeek());
+            routine.setUser(user);
+            if (routine.getActivities() != null && !routine.getActivities().isEmpty()) {
+                routineActivityRepository.deleteAll(new ArrayList<>(routine.getActivities()));
+                routine.getActivities().clear();
             }
-            routineActivityRepository.saveAll(acts);
-            routine.setActivities(acts);
+            if (input.getActivityInputs() != null) {
+                List<RoutineActivity> acts = new ArrayList<>();
+                for (RoutineActivityInputDTO ai : input.getActivityInputs()) {
+                    Habit habit = habitRepository.findById(ai.getHabitId())
+                            .orElseThrow(() -> {
+                                logger.warn("Habit {} not found for routine update", ai.getHabitId());
+                                return new NoSuchElementException("Habit not found");
+                            });
+                    RoutineActivity ra = new RoutineActivity();
+                    ra.setHabit(habit);
+                    ra.setDuration(ai.getDuration());
+                    ra.setTargetTime(ai.getTargetTime() != null ? ai.getTargetTime() : 0);
+                    ra.setNotes(ai.getNotes());
+                    ra.setRoutine(routine);
+                    acts.add(ra);
+                }
+                routineActivityRepository.saveAll(acts);
+                routine.setActivities(acts);
+            }
+            routine = routineRepository.save(routine);
+            RoutineOutputDTO output = io.convertToOutput(routine);
+            logger.info("Updated routine {} successfully", id);
+            return output;
+        } catch (NoSuchElementException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error updating routine {}", id, ex);
+            throw ex;
         }
-        routine = routineRepository.save(routine);
-        return io.convertToOutput(routine);
     }
 
     @Override
     @Transactional
     public boolean delete(Long id) {
-        Routine routine = routineRepository.findById(id).orElse(null);
-        if (routine == null) return false;
-        if (routine.getActivities() != null && !routine.getActivities().isEmpty()) {
-            routineActivityRepository.deleteAll(new ArrayList<>(routine.getActivities()));
+        logger.info("Deleting routine {}", id);
+        try {
+            Routine routine = routineRepository.findById(id).orElse(null);
+            if (routine == null) {
+                logger.warn("Routine {} not found for deletion", id);
+                return false;
+            }
+            if (routine.getActivities() != null && !routine.getActivities().isEmpty()) {
+                routineActivityRepository.deleteAll(new ArrayList<>(routine.getActivities()));
+            }
+            routineRepository.deleteById(id);
+            logger.info("Deleted routine {}", id);
+            return true;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error deleting routine {}", id, ex);
+            throw ex;
         }
-        routineRepository.deleteById(id);
-        return true;
     }
 
 }

--- a/src/main/java/task/healthyhabits/services/routineActivity/RoutineActivityServiceImplementation.java
+++ b/src/main/java/task/healthyhabits/services/routineActivity/RoutineActivityServiceImplementation.java
@@ -1,6 +1,8 @@
 package task.healthyhabits.services.routineActivity;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,7 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 public class RoutineActivityServiceImplementation implements RoutineActivityService {
 
+    private static final Logger logger = LogManager.getLogger(RoutineActivityServiceImplementation.class);
     private final RoutineActivityRepository routineActivityRepository;
     private final RoutineRepository routineRepository;
     private final HabitRepository habitRepository;
@@ -31,8 +34,16 @@ public class RoutineActivityServiceImplementation implements RoutineActivityServ
     @Override
     @Transactional(readOnly = true)
     public Page<RoutineActivityDTO> list(Pageable pageable) {
-        return routineActivityRepository.findAll(pageable)
-                .map(entity -> mapperFactory.createMapper(RoutineActivity.class, RoutineActivityDTO.class).convertToDTO(entity));
+        logger.info("Listing routine activities with pageable {}", pageable);
+        try {
+            Page<RoutineActivityDTO> activities = routineActivityRepository.findAll(pageable)
+                    .map(entity -> mapperFactory.createMapper(RoutineActivity.class, RoutineActivityDTO.class).convertToDTO(entity));
+            logger.info("Listed {} routine activities", activities.getNumberOfElements());
+            return activities;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error listing routine activities with pageable {}", pageable, ex);
+            throw ex;
+        }
     }
 
     @Override
@@ -46,44 +57,86 @@ public class RoutineActivityServiceImplementation implements RoutineActivityServ
     @Override
     @Transactional
     public RoutineActivityOutputDTO create(Long routineId, RoutineActivityInputDTO input) {
-        InputOutputMapper<RoutineActivityInputDTO, RoutineActivity, RoutineActivityOutputDTO> io =
-                mapperFactory.createInputOutputMapper(RoutineActivityInputDTO.class, RoutineActivity.class, RoutineActivityOutputDTO.class);
-        Routine routine = routineRepository.findById(routineId)
-                .orElseThrow(() -> new NoSuchElementException("Routine not found"));
-        Habit habit = habitRepository.findById(input.getHabitId())
-                .orElseThrow(() -> new NoSuchElementException("Habit not found"));
-        RoutineActivity ra = new RoutineActivity();
-        ra.setRoutine(routine);
-        ra.setHabit(habit);
-        ra.setDuration(input.getDuration());
-        ra.setTargetTime(input.getTargetTime() != null ? input.getTargetTime() : 0);
-        ra.setNotes(input.getNotes());
-        ra = routineActivityRepository.save(ra);
-        return io.convertToOutput(ra);
+        logger.info("Creating routine activity for routine {} with input {}", routineId, input);
+        try {
+            InputOutputMapper<RoutineActivityInputDTO, RoutineActivity, RoutineActivityOutputDTO> io =
+                    mapperFactory.createInputOutputMapper(RoutineActivityInputDTO.class, RoutineActivity.class, RoutineActivityOutputDTO.class);
+            Routine routine = routineRepository.findById(routineId)
+                    .orElseThrow(() -> {
+                        logger.warn("Routine {} not found for activity creation", routineId);
+                        return new NoSuchElementException("Routine not found");
+                    });
+            Habit habit = habitRepository.findById(input.getHabitId())
+                    .orElseThrow(() -> {
+                        logger.warn("Habit {} not found for routine activity creation", input.getHabitId());
+                        return new NoSuchElementException("Habit not found");
+                    });
+            RoutineActivity ra = new RoutineActivity();
+            ra.setRoutine(routine);
+            ra.setHabit(habit);
+            ra.setDuration(input.getDuration());
+            ra.setTargetTime(input.getTargetTime() != null ? input.getTargetTime() : 0);
+            ra.setNotes(input.getNotes());
+            ra = routineActivityRepository.save(ra);
+            RoutineActivityOutputDTO output = io.convertToOutput(ra);
+            logger.info("Created routine activity {} for routine {}", ra.getId(), routineId);
+            return output;
+        } catch (NoSuchElementException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error creating routine activity for routine {}", routineId, ex);
+            throw ex;
+        }
     }
 
     @Override
     @Transactional
     public RoutineActivityOutputDTO update(Long id, RoutineActivityInputDTO input) {
-        InputOutputMapper<RoutineActivityInputDTO, RoutineActivity, RoutineActivityOutputDTO> io =
-                mapperFactory.createInputOutputMapper(RoutineActivityInputDTO.class, RoutineActivity.class, RoutineActivityOutputDTO.class);
-        RoutineActivity ra = routineActivityRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("RoutineActivity not found"));
-        Habit habit = habitRepository.findById(input.getHabitId())
-                .orElseThrow(() -> new NoSuchElementException("Habit not found"));
-        ra.setHabit(habit);
-        if (input.getDuration() != null) ra.setDuration(input.getDuration());
-        if (input.getTargetTime() != null) ra.setTargetTime(input.getTargetTime());
-        ra.setNotes(input.getNotes());
-        ra = routineActivityRepository.save(ra);
-        return io.convertToOutput(ra);
+        logger.info("Updating routine activity {} with input {}", id, input);
+        try {
+            InputOutputMapper<RoutineActivityInputDTO, RoutineActivity, RoutineActivityOutputDTO> io =
+                    mapperFactory.createInputOutputMapper(RoutineActivityInputDTO.class, RoutineActivity.class, RoutineActivityOutputDTO.class);
+            RoutineActivity ra = routineActivityRepository.findById(id)
+                    .orElseThrow(() -> {
+                        logger.warn("Routine activity {} not found for update", id);
+                        return new NoSuchElementException("RoutineActivity not found");
+                    });
+            Habit habit = habitRepository.findById(input.getHabitId())
+                    .orElseThrow(() -> {
+                        logger.warn("Habit {} not found for routine activity update", input.getHabitId());
+                        return new NoSuchElementException("Habit not found");
+                    });
+            ra.setHabit(habit);
+            if (input.getDuration() != null) ra.setDuration(input.getDuration());
+            if (input.getTargetTime() != null) ra.setTargetTime(input.getTargetTime());
+            ra.setNotes(input.getNotes());
+            ra = routineActivityRepository.save(ra);
+            RoutineActivityOutputDTO output = io.convertToOutput(ra);
+            logger.info("Updated routine activity {} successfully", id);
+            return output;
+        } catch (NoSuchElementException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error updating routine activity {}", id, ex);
+            throw ex;
+        }
     }
 
     @Override
     @Transactional
     public boolean delete(Long id) {
-        if (!routineActivityRepository.existsById(id)) return false;
-        routineActivityRepository.deleteById(id);
-        return true;
+        logger.info("Deleting routine activity {}", id);
+        try {
+            if (!routineActivityRepository.existsById(id)) {
+                logger.warn("Routine activity {} not found for deletion", id);
+                return false;
+            }
+            routineActivityRepository.deleteById(id);
+            logger.info("Deleted routine activity {}", id);
+            return true;
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error deleting routine activity {}", id, ex);
+            throw ex;
+        }
     }
 }

--- a/src/main/java/task/healthyhabits/services/stats/StatsServiceImplementation.java
+++ b/src/main/java/task/healthyhabits/services/stats/StatsServiceImplementation.java
@@ -1,6 +1,8 @@
 package task.healthyhabits.services.stats;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import task.healthyhabits.models.Category;
@@ -18,10 +20,12 @@ import java.util.Map;
 @Transactional(readOnly = true)
 public class StatsServiceImplementation implements StatsService {
 
+    private static final Logger logger = LogManager.getLogger(StatsServiceImplementation.class);
     private final CompletedActivityRepository completedActivityRepository;
 
     @Override
     public LinkedHashMap<LocalDate, Integer> weeklyDailyCounts(Long userId, LocalDate weekStart) {
+        logger.info("Calculating weekly daily counts for user {} starting {}", userId, weekStart);
         LocalDate start = weekStart;
         OffsetDateTime startDt = start.atStartOfDay().atOffset(ZoneOffset.UTC);
         OffsetDateTime endDt = start.plusDays(7).atStartOfDay().atOffset(ZoneOffset.UTC);
@@ -36,11 +40,13 @@ public class StatsServiceImplementation implements StatsService {
             int count = ((Number) row[1]).intValue();
             result.put(day, count);
         }
+        logger.info("Calculated weekly daily counts for user {}", userId);
         return result;
     }
 
     @Override
     public Map<Category, Integer> monthlyCategoryCounts(Long userId, int month, int year) {
+        logger.info("Calculating monthly category counts for user {} month {} year {}", userId, month, year);
         LocalDate start = LocalDate.of(year, month, 1);
         OffsetDateTime startDt = start.atStartOfDay().atOffset(ZoneOffset.UTC);
         OffsetDateTime endDt = start.plusMonths(1).atStartOfDay().atOffset(ZoneOffset.UTC);
@@ -54,6 +60,7 @@ public class StatsServiceImplementation implements StatsService {
                 byCategory.put(category, count);
             }
         }
+        logger.info("Calculated monthly category counts for user {}", userId);
         return byCategory;
     }
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <JsonLayout compact="true" eventEol="true" />
+      <JsonLayout compact="true" eventEol="true" locationInfo="true" properties="true" stacktrace="true" />
     </Console>
   </Appenders>
   <Loggers>


### PR DESCRIPTION
## Summary
- add Log4j loggers to the service implementations to log list, create, update, and delete operations, including warnings for missing resources and errors before propagating unexpected failures
- expand the JsonLayout in `log4j2.xml` so audit output includes location, properties, and stack traces

## Testing
- `./mvnw test` *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4dedd250832cbe00a51b91d2669d