### PR TITLE
Add routine GraphQL resolvers and tests

### DIFF
--- a/src/main/java/task/healthyhabits/resolvers/routineActivities/RoutineActivityMutationResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/routineActivities/RoutineActivityMutationResolver.java
@@ -1,0 +1,40 @@
+package task.healthyhabits.resolvers.routineActivities;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.stereotype.Controller;
+import task.healthyhabits.dtos.inputs.RoutineActivityInputDTO;
+import task.healthyhabits.dtos.outputs.RoutineActivityOutputDTO;
+import task.healthyhabits.models.Permission;
+import task.healthyhabits.services.routineActivity.RoutineActivityService;
+
+import static task.healthyhabits.security.SecurityUtils.requireAny;
+
+@Controller
+@RequiredArgsConstructor
+public class RoutineActivityMutationResolver {
+
+    private final RoutineActivityService routineActivityService;
+
+    @MutationMapping
+    public RoutineActivityOutputDTO createRoutineActivity(@Argument Long routineId,
+                                                          @Argument("input") @Valid RoutineActivityInputDTO input) {
+        requireAny(Permission.ROUTINE_EDITOR);
+        return routineActivityService.create(routineId, input);
+    }
+
+    @MutationMapping
+    public RoutineActivityOutputDTO updateRoutineActivity(@Argument Long id,
+                                                          @Argument("input") @Valid RoutineActivityInputDTO input) {
+        requireAny(Permission.ROUTINE_EDITOR);
+        return routineActivityService.update(id, input);
+    }
+
+    @MutationMapping
+    public Boolean deleteRoutineActivity(@Argument Long id) {
+        requireAny(Permission.ROUTINE_EDITOR);
+        return routineActivityService.delete(id);
+    }
+}

--- a/src/main/java/task/healthyhabits/resolvers/routineActivities/RoutineActivityQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/routineActivities/RoutineActivityQueryResolver.java
@@ -1,0 +1,41 @@
+package task.healthyhabits.resolvers.routineActivities;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+import task.healthyhabits.dtos.normals.RoutineActivityDTO;
+import task.healthyhabits.models.Permission;
+import task.healthyhabits.services.routineActivity.RoutineActivityService;
+
+import java.util.List;
+
+import static task.healthyhabits.security.SecurityUtils.requireAny;
+
+@Controller
+@RequiredArgsConstructor
+public class RoutineActivityQueryResolver {
+
+    private final RoutineActivityService routineActivityService;
+
+    @QueryMapping
+    public RoutineActivityPage listRoutineActivities(@Argument int page, @Argument int size) {
+        requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<RoutineActivityDTO> p = routineActivityService.list(pageable);
+        return new RoutineActivityPage(p.getContent(), p.getTotalPages(), (int) p.getTotalElements(), p.getSize(), p.getNumber());
+    }
+
+    @QueryMapping
+    public RoutineActivityDTO getRoutineActivityById(@Argument Long id) {
+        requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR);
+        return routineActivityService.findByIdOrNull(id);
+    }
+
+    public record RoutineActivityPage(List<RoutineActivityDTO> content, int totalPages, int totalElements, int size,
+                                      int number) {
+    }
+}

--- a/src/main/java/task/healthyhabits/resolvers/routines/RoutineMutationResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/routines/RoutineMutationResolver.java
@@ -1,0 +1,38 @@
+package task.healthyhabits.resolvers.routines;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.stereotype.Controller;
+import task.healthyhabits.dtos.inputs.RoutineInputDTO;
+import task.healthyhabits.dtos.outputs.RoutineOutputDTO;
+import task.healthyhabits.models.Permission;
+import task.healthyhabits.services.routine.RoutineService;
+
+import static task.healthyhabits.security.SecurityUtils.requireAny;
+
+@Controller
+@RequiredArgsConstructor
+public class RoutineMutationResolver {
+
+    private final RoutineService routineService;
+
+    @MutationMapping
+    public RoutineOutputDTO createRoutine(@Argument("input") @Valid RoutineInputDTO input) {
+        requireAny(Permission.ROUTINE_EDITOR);
+        return routineService.create(input);
+    }
+
+    @MutationMapping
+    public RoutineOutputDTO updateRoutine(@Argument Long id, @Argument("input") @Valid RoutineInputDTO input) {
+        requireAny(Permission.ROUTINE_EDITOR);
+        return routineService.update(id, input);
+    }
+
+    @MutationMapping
+    public Boolean deleteRoutine(@Argument Long id) {
+        requireAny(Permission.ROUTINE_EDITOR);
+        return routineService.delete(id);
+    }
+}

--- a/src/main/java/task/healthyhabits/resolvers/routines/RoutineQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/routines/RoutineQueryResolver.java
@@ -1,0 +1,63 @@
+package task.healthyhabits.resolvers.routines;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+import task.healthyhabits.dtos.normals.RoutineDTO;
+import task.healthyhabits.models.Permission;
+import task.healthyhabits.repositories.UserRepository;
+import task.healthyhabits.services.routine.RoutineService;
+
+import java.util.List;
+
+import static task.healthyhabits.security.SecurityUtils.requireAny;
+
+@Controller
+@RequiredArgsConstructor
+public class RoutineQueryResolver {
+
+    private final RoutineService routineService;
+    private final UserRepository userRepository;
+
+    @QueryMapping
+    public RoutinePage listRoutines(@Argument int page, @Argument int size) {
+        requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<RoutineDTO> p = routineService.list(pageable);
+        return new RoutinePage(p.getContent(), p.getTotalPages(), (int) p.getTotalElements(), p.getSize(), p.getNumber());
+    }
+
+    @QueryMapping
+    public RoutinePage listMyRoutines(@Argument int page, @Argument int size) {
+        requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR);
+        Long userId = userRepository
+                .findByEmail(org.springframework.security.core.context.SecurityContextHolder.getContext()
+                        .getAuthentication().getName())
+                .orElseThrow(() -> new IllegalStateException("Authenticated user not found"))
+                .getId();
+        Pageable pageable = PageRequest.of(page, size);
+        Page<RoutineDTO> p = routineService.myRoutines(userId, pageable);
+        return new RoutinePage(p.getContent(), p.getTotalPages(), (int) p.getTotalElements(), p.getSize(), p.getNumber());
+    }
+
+    @QueryMapping
+    public RoutinePage listRoutinesByUser(@Argument Long userId, @Argument int page, @Argument int size) {
+        requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<RoutineDTO> p = routineService.byUser(userId, pageable);
+        return new RoutinePage(p.getContent(), p.getTotalPages(), (int) p.getTotalElements(), p.getSize(), p.getNumber());
+    }
+
+    @QueryMapping
+    public RoutineDTO getRoutineById(@Argument Long id) {
+        requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR);
+        return routineService.findByIdOrNull(id);
+    }
+
+    public record RoutinePage(List<RoutineDTO> content, int totalPages, int totalElements, int size, int number) {
+    }
+}

--- a/src/test/java/task/healthyhabits/tests/resolvers/routineActivities/RoutineActivityMutationResolverTest.java
+++ b/src/test/java/task/healthyhabits/tests/resolvers/routineActivities/RoutineActivityMutationResolverTest.java
@@ -1,0 +1,89 @@
+package task.healthyhabits.tests.resolvers.routineActivities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import task.healthyhabits.dtos.inputs.RoutineActivityInputDTO;
+import task.healthyhabits.dtos.outputs.HabitOutputDTO;
+import task.healthyhabits.dtos.outputs.RoutineActivityOutputDTO;
+import task.healthyhabits.dtos.outputs.RoutineOutputDTO;
+import task.healthyhabits.dtos.outputs.UserOutputDTO;
+import task.healthyhabits.models.Category;
+import task.healthyhabits.models.DaysOfWeek;
+import task.healthyhabits.models.Permission;
+import task.healthyhabits.resolvers.routineActivities.RoutineActivityMutationResolver;
+import task.healthyhabits.security.SecurityUtils;
+import task.healthyhabits.services.routineActivity.RoutineActivityService;
+
+@ExtendWith(MockitoExtension.class)
+class RoutineActivityMutationResolverTest {
+
+    @Mock
+    private RoutineActivityService routineActivityService;
+
+    @InjectMocks
+    private RoutineActivityMutationResolver resolver;
+
+    @Test
+    void createRoutineActivityDelegatesToService() {
+        RoutineActivityInputDTO input = new RoutineActivityInputDTO(3L, 25, 40, "Core strength");
+        RoutineActivityOutputDTO output = new RoutineActivityOutputDTO(11L,
+                new HabitOutputDTO(3L, "Plank", Category.PHYSICAL, "Core exercise"), 25, 40, "Core strength",
+                new RoutineOutputDTO(4L, "Fitness", new UserOutputDTO(7L, "Sam", "sam@example.com", List.of(), List.of(), null),
+                        "Stay fit", List.of("fitness"), List.of(DaysOfWeek.MONDAY), List.of()));
+        when(routineActivityService.create(4L, input)).thenReturn(output);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutineActivityOutputDTO result = resolver.createRoutineActivity(4L, input);
+
+            assertThat(result).isEqualTo(output);
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineActivityService).create(4L, input);
+    }
+
+    @Test
+    void updateRoutineActivityDelegatesToService() {
+        RoutineActivityInputDTO input = new RoutineActivityInputDTO(5L, 15, 25, "Cool down");
+        RoutineActivityOutputDTO output = new RoutineActivityOutputDTO(9L,
+                new HabitOutputDTO(5L, "Yoga", Category.MENTAL, "Yoga flow"), 15, 25, "Cool down",
+                new RoutineOutputDTO(8L, "Wellness", new UserOutputDTO(9L, "Taylor", "taylor@example.com", List.of(), List.of(), null),
+                        "Daily wellness", List.of("balance"), List.of(DaysOfWeek.TUESDAY), List.of()));
+        when(routineActivityService.update(9L, input)).thenReturn(output);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutineActivityOutputDTO result = resolver.updateRoutineActivity(9L, input);
+
+            assertThat(result).isEqualTo(output);
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineActivityService).update(9L, input);
+    }
+
+    @Test
+    void deleteRoutineActivityDelegatesToService() {
+        when(routineActivityService.delete(12L)).thenReturn(Boolean.TRUE);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            Boolean result = resolver.deleteRoutineActivity(12L);
+
+            assertThat(result).isTrue();
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineActivityService).delete(12L);
+    }
+}

--- a/src/test/java/task/healthyhabits/tests/resolvers/routineActivities/RoutineActivityQueryResolverTest.java
+++ b/src/test/java/task/healthyhabits/tests/resolvers/routineActivities/RoutineActivityQueryResolverTest.java
@@ -1,0 +1,76 @@
+package task.healthyhabits.tests.resolvers.routineActivities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import task.healthyhabits.dtos.normals.HabitDTO;
+import task.healthyhabits.dtos.normals.RoutineActivityDTO;
+import task.healthyhabits.models.Category;
+import task.healthyhabits.models.Permission;
+import task.healthyhabits.resolvers.routineActivities.RoutineActivityQueryResolver;
+import task.healthyhabits.resolvers.routineActivities.RoutineActivityQueryResolver.RoutineActivityPage;
+import task.healthyhabits.security.SecurityUtils;
+import task.healthyhabits.services.routineActivity.RoutineActivityService;
+
+@ExtendWith(MockitoExtension.class)
+class RoutineActivityQueryResolverTest {
+
+    @Mock
+    private RoutineActivityService routineActivityService;
+
+    @InjectMocks
+    private RoutineActivityQueryResolver resolver;
+
+    @Test
+    void listRoutineActivitiesReturnsServicePage() {
+        HabitDTO habit = new HabitDTO(2L, "Jog", Category.PHYSICAL, "Morning jog");
+        RoutineActivityDTO dto = new RoutineActivityDTO(1L, habit, 30, 45, "", null);
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<RoutineActivityDTO> page = new PageImpl<>(List.of(dto), pageable, 1);
+        when(routineActivityService.list(pageable)).thenReturn(page);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutineActivityPage result = resolver.listRoutineActivities(0, 5);
+
+            assertThat(result.content()).containsExactly(dto);
+            assertThat(result.totalPages()).isEqualTo(page.getTotalPages());
+            assertThat(result.totalElements()).isEqualTo(page.getTotalElements());
+            assertThat(result.size()).isEqualTo(page.getSize());
+            assertThat(result.number()).isEqualTo(page.getNumber());
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineActivityService).list(pageable);
+    }
+
+    @Test
+    void getRoutineActivityByIdDelegatesToService() {
+        HabitDTO habit = new HabitDTO(3L, "Stretch", Category.PHYSICAL, "Evening stretch");
+        RoutineActivityDTO dto = new RoutineActivityDTO(5L, habit, 15, 20, "", null);
+        when(routineActivityService.findByIdOrNull(5L)).thenReturn(dto);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutineActivityDTO result = resolver.getRoutineActivityById(5L);
+
+            assertThat(result).isEqualTo(dto);
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineActivityService).findByIdOrNull(5L);
+    }
+}

--- a/src/test/java/task/healthyhabits/tests/resolvers/routines/RoutineMutationResolverTest.java
+++ b/src/test/java/task/healthyhabits/tests/resolvers/routines/RoutineMutationResolverTest.java
@@ -1,0 +1,96 @@
+package task.healthyhabits.tests.resolvers.routines;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import task.healthyhabits.dtos.inputs.RoutineActivityInputDTO;
+import task.healthyhabits.dtos.inputs.RoutineInputDTO;
+import task.healthyhabits.dtos.outputs.HabitOutputDTO;
+import task.healthyhabits.dtos.outputs.RoutineActivityOutputDTO;
+import task.healthyhabits.dtos.outputs.RoutineOutputDTO;
+import task.healthyhabits.dtos.outputs.UserOutputDTO;
+import task.healthyhabits.models.Category;
+import task.healthyhabits.models.DaysOfWeek;
+import task.healthyhabits.models.Permission;
+import task.healthyhabits.resolvers.routines.RoutineMutationResolver;
+import task.healthyhabits.security.SecurityUtils;
+import task.healthyhabits.services.routine.RoutineService;
+
+@ExtendWith(MockitoExtension.class)
+class RoutineMutationResolverTest {
+
+    @Mock
+    private RoutineService routineService;
+
+    @InjectMocks
+    private RoutineMutationResolver resolver;
+
+    @Test
+    void createRoutineDelegatesToService() {
+        RoutineActivityInputDTO activityInput = new RoutineActivityInputDTO(9L, 30, 45, "Focus");
+        RoutineInputDTO input = new RoutineInputDTO("Mindful Start", "Begin with mindfulness", List.of("calm"),
+                List.of(DaysOfWeek.MONDAY), 5L, List.of(activityInput));
+        RoutineActivityOutputDTO activityOutput = new RoutineActivityOutputDTO(2L,
+                new HabitOutputDTO(9L, "Breathing", Category.MENTAL, "Deep breathing"), 30, 45, "Focus", null);
+        RoutineOutputDTO output = new RoutineOutputDTO(3L, "Mindful Start",
+                new UserOutputDTO(5L, "Alex", "alex@example.com", List.of(), List.of(), null),
+                "Begin with mindfulness", List.of("calm"), List.of(DaysOfWeek.MONDAY), List.of(activityOutput));
+        when(routineService.create(input)).thenReturn(output);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutineOutputDTO result = resolver.createRoutine(input);
+
+            assertThat(result).isEqualTo(output);
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineService).create(input);
+    }
+
+    @Test
+    void updateRoutineDelegatesToService() {
+        RoutineActivityInputDTO activityInput = new RoutineActivityInputDTO(7L, 20, 30, "Evening");
+        RoutineInputDTO input = new RoutineInputDTO("Evening Relax", "Relax before bed", List.of("relax"),
+                List.of(DaysOfWeek.FRIDAY), 8L, List.of(activityInput));
+        RoutineActivityOutputDTO activityOutput = new RoutineActivityOutputDTO(4L,
+                new HabitOutputDTO(7L, "Stretch", Category.PHYSICAL, "Light stretches"), 20, 30, "Evening", null);
+        RoutineOutputDTO output = new RoutineOutputDTO(6L, "Evening Relax",
+                new UserOutputDTO(8L, "Jamie", "jamie@example.com", List.of(), List.of(), null),
+                "Relax before bed", List.of("relax"), List.of(DaysOfWeek.FRIDAY), List.of(activityOutput));
+        when(routineService.update(6L, input)).thenReturn(output);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutineOutputDTO result = resolver.updateRoutine(6L, input);
+
+            assertThat(result).isEqualTo(output);
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineService).update(6L, input);
+    }
+
+    @Test
+    void deleteRoutineDelegatesToService() {
+        when(routineService.delete(10L)).thenReturn(Boolean.TRUE);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            Boolean result = resolver.deleteRoutine(10L);
+
+            assertThat(result).isTrue();
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineService).delete(10L);
+    }
+}

--- a/src/test/java/task/healthyhabits/tests/resolvers/routines/RoutineQueryResolverTest.java
+++ b/src/test/java/task/healthyhabits/tests/resolvers/routines/RoutineQueryResolverTest.java
@@ -1,0 +1,155 @@
+package task.healthyhabits.tests.resolvers.routines;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import task.healthyhabits.dtos.normals.HabitDTO;
+import task.healthyhabits.dtos.normals.RoutineActivityDTO;
+import task.healthyhabits.dtos.normals.RoutineDTO;
+import task.healthyhabits.dtos.normals.UserDTO;
+import task.healthyhabits.models.Category;
+import task.healthyhabits.models.DaysOfWeek;
+import task.healthyhabits.models.Permission;
+import task.healthyhabits.models.User;
+import task.healthyhabits.repositories.UserRepository;
+import task.healthyhabits.resolvers.routines.RoutineQueryResolver;
+import task.healthyhabits.resolvers.routines.RoutineQueryResolver.RoutinePage;
+import task.healthyhabits.security.SecurityUtils;
+import task.healthyhabits.services.routine.RoutineService;
+
+@ExtendWith(MockitoExtension.class)
+class RoutineQueryResolverTest {
+
+    @Mock
+    private RoutineService routineService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private RoutineQueryResolver resolver;
+
+    private final UserDTO userDto = new UserDTO(5L, "Alex", "alex@example.com", "password", List.of(), List.of(), null);
+    private final HabitDTO habitDto = new HabitDTO(7L, "Meditate", Category.MENTAL, "Morning meditation");
+
+    @AfterEach
+    void cleanupSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void listRoutinesReturnsServicePage() {
+        RoutineDTO routine = new RoutineDTO(1L, "Daily Wellness", userDto, "Stay balanced", List.of("calm"),
+                List.of(DaysOfWeek.MONDAY), List.of(new RoutineActivityDTO(3L, habitDto, 15, 30, "", null)));
+        Pageable pageable = PageRequest.of(0, 4);
+        Page<RoutineDTO> page = new PageImpl<>(List.of(routine), pageable, 1);
+        when(routineService.list(pageable)).thenReturn(page);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutinePage result = resolver.listRoutines(0, 4);
+
+            assertThat(result.content()).containsExactly(routine);
+            assertThat(result.totalPages()).isEqualTo(page.getTotalPages());
+            assertThat(result.totalElements()).isEqualTo(page.getTotalElements());
+            assertThat(result.size()).isEqualTo(page.getSize());
+            assertThat(result.number()).isEqualTo(page.getNumber());
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineService).list(pageable);
+    }
+
+    @Test
+    void listMyRoutinesUsesAuthenticatedUser() {
+        setupAuthentication("alex@example.com");
+        User user = new User(5L, "Alex", "alex@example.com", "password", List.of(), List.of(), null);
+        when(userRepository.findByEmail("alex@example.com")).thenReturn(Optional.of(user));
+
+        RoutineDTO routine = new RoutineDTO(2L, "Strength Plan", userDto, "Build strength", List.of("fitness"),
+                List.of(DaysOfWeek.TUESDAY), List.of(new RoutineActivityDTO(4L, habitDto, 20, 40, "", null)));
+        Pageable pageable = PageRequest.of(1, 2);
+        Page<RoutineDTO> page = new PageImpl<>(List.of(routine), pageable, 1);
+        when(routineService.myRoutines(5L, pageable)).thenReturn(page);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutinePage result = resolver.listMyRoutines(1, 2);
+
+            assertThat(result.content()).containsExactly(routine);
+            assertThat(result.totalPages()).isEqualTo(page.getTotalPages());
+            assertThat(result.totalElements()).isEqualTo(page.getTotalElements());
+            assertThat(result.size()).isEqualTo(page.getSize());
+            assertThat(result.number()).isEqualTo(page.getNumber());
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR));
+        }
+
+        verify(userRepository).findByEmail("alex@example.com");
+        verify(routineService).myRoutines(5L, pageable);
+    }
+
+    @Test
+    void listRoutinesByUserDelegatesToService() {
+        RoutineDTO routine = new RoutineDTO(3L, "Flexibility", userDto, "Stretching", List.of("mobility"),
+                List.of(DaysOfWeek.WEDNESDAY), List.of(new RoutineActivityDTO(6L, habitDto, 25, 45, "", null)));
+        Pageable pageable = PageRequest.of(2, 3);
+        Page<RoutineDTO> page = new PageImpl<>(List.of(routine), pageable, 1);
+        when(routineService.byUser(5L, pageable)).thenReturn(page);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutinePage result = resolver.listRoutinesByUser(5L, 2, 3);
+
+            assertThat(result.content()).containsExactly(routine);
+            assertThat(result.totalPages()).isEqualTo(page.getTotalPages());
+            assertThat(result.totalElements()).isEqualTo(page.getTotalElements());
+            assertThat(result.size()).isEqualTo(page.getSize());
+            assertThat(result.number()).isEqualTo(page.getNumber());
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineService).byUser(5L, pageable);
+    }
+
+    @Test
+    void getRoutineByIdDelegatesToService() {
+        RoutineDTO routine = new RoutineDTO(9L, "Evening Calm", userDto, "Wind down", List.of("relax"),
+                List.of(DaysOfWeek.FRIDAY), List.of(new RoutineActivityDTO(8L, habitDto, 10, 20, "", null)));
+        when(routineService.findByIdOrNull(9L)).thenReturn(routine);
+
+        try (MockedStatic<SecurityUtils> mockedSecurity = mockStatic(SecurityUtils.class)) {
+            RoutineDTO result = resolver.getRoutineById(9L);
+
+            assertThat(result).isEqualTo(routine);
+            mockedSecurity.verify(() -> SecurityUtils.requireAny(Permission.ROUTINE_READ, Permission.ROUTINE_EDITOR));
+        }
+
+        verify(routineService).findByIdOrNull(9L);
+    }
+
+    private void setupAuthentication(String email) {
+        SecurityContext context = mock(SecurityContext.class);
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn(email);
+        when(context.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+}


### PR DESCRIPTION
## Summary
- add GraphQL query and mutation resolvers for routines and routine activities with permission checks
- expose paginated responses consistent with the schema and current user lookups for personal routines
- create resolver unit tests that verify pagination data, service delegation, and security enforcement

## Testing
- `./mvnw test` *(fails: network is unreachable when downloading the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb556a0e0832c9b50b07a11161f15