### PR TITLE
Add pagination navigation metadata to page DTOs and schema

### DIFF
--- a/src/main/java/task/healthyhabits/dtos/pages/PageDTO.java
+++ b/src/main/java/task/healthyhabits/dtos/pages/PageDTO.java
@@ -7,8 +7,17 @@ public record PageDTO<T>(
         int totalPages,
         long totalElements,
         int size,
-        int number) {
+        int number,
+        boolean hasNext,
+        boolean hasPrevious) {
     public static <T> PageDTO<T> from(org.springframework.data.domain.Page<T> p) {
-        return new PageDTO<>(p.getContent(), p.getTotalPages(), p.getTotalElements(), p.getSize(), p.getNumber());
+        return new PageDTO<>(
+                p.getContent(),
+                p.getTotalPages(),
+                p.getTotalElements(),
+                p.getSize(),
+                p.getNumber(),
+                p.hasNext(),
+                p.hasPrevious());
     }
 }

--- a/src/main/java/task/healthyhabits/resolvers/guides/GuideQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/guides/GuideQueryResolver.java
@@ -53,9 +53,23 @@ public class GuideQueryResolver {
         return guideService.findByIdOrNull(id);
     }
 
-    public record GuidePage(List<GuideDTO> content, int totalPages, long totalElements, int size, int number) {
+    public record GuidePage(
+            List<GuideDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static GuidePage from(PageDTO<GuideDTO> dto) {
-            return new GuidePage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(), dto.number());
+            return new GuidePage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 }

--- a/src/main/java/task/healthyhabits/resolvers/habits/HabitQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/habits/HabitQueryResolver.java
@@ -44,9 +44,23 @@ public class HabitQueryResolver {
         return habitService.findByIdOrNull(id);
     }
 
-    public record HabitPage(List<HabitDTO> content, int totalPages, int totalElements, int size, int number) {
+    public record HabitPage(
+            List<HabitDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static HabitPage from(PageDTO<HabitDTO> dto) {
-            return new HabitPage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(), dto.number());
+            return new HabitPage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 }

--- a/src/main/java/task/healthyhabits/resolvers/progress/ProgressQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/progress/ProgressQueryResolver.java
@@ -98,18 +98,43 @@ public class ProgressQueryResolver {
         return List.of(new MonthlyStat(month, year, list));
     }
 
-    public record ProgressLogPage(List<ProgressLogDTO> content, int totalPages, long totalElements, int size,
-            int number) {
+    public record ProgressLogPage(
+            List<ProgressLogDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static ProgressLogPage from(PageDTO<ProgressLogDTO> dto) {
-            return new ProgressLogPage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(), dto.number());
+            return new ProgressLogPage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 
-    public record CompletedActivityPage(List<CompletedActivityDTO> content, int totalPages, long totalElements,
-            int size, int number) {
+    public record CompletedActivityPage(
+            List<CompletedActivityDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static CompletedActivityPage from(PageDTO<CompletedActivityDTO> dto) {
-            return new CompletedActivityPage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(),
-                    dto.number());
+            return new CompletedActivityPage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 

--- a/src/main/java/task/healthyhabits/resolvers/reminders/ReminderQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/reminders/ReminderQueryResolver.java
@@ -50,9 +50,23 @@ public class ReminderQueryResolver {
         return reminderService.findByIdOrNull(id);
     }
 
-    public record ReminderPage(List<ReminderDTO> content, int totalPages, long totalElements, int size, int number) {
+    public record ReminderPage(
+            List<ReminderDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static ReminderPage from(PageDTO<ReminderDTO> dto) {
-            return new ReminderPage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(), dto.number());
+            return new ReminderPage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 }

--- a/src/main/java/task/healthyhabits/resolvers/roles/RoleQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/roles/RoleQueryResolver.java
@@ -35,9 +35,23 @@ public class RoleQueryResolver {
         return roleService.findByIdOrNull(id);
     }
 
-    public record RolePage(List<RoleDTO> content, int totalPages, long totalElements, int size, int number) {
+    public record RolePage(
+            List<RoleDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static RolePage from(PageDTO<RoleDTO> dto) {
-            return new RolePage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(), dto.number());
+            return new RolePage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
- }
+}

--- a/src/main/java/task/healthyhabits/resolvers/routineActivities/RoutineActivityQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/routineActivities/RoutineActivityQueryResolver.java
@@ -35,11 +35,23 @@ public class RoutineActivityQueryResolver {
         return routineActivityService.findByIdOrNull(id);
     }
 
-    public record RoutineActivityPage(List<RoutineActivityDTO> content, int totalPages, long totalElements, int size,
-            int number) {
+    public record RoutineActivityPage(
+            List<RoutineActivityDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static RoutineActivityPage from(PageDTO<RoutineActivityDTO> dto) {
-            return new RoutineActivityPage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(),
-                    dto.number());
+            return new RoutineActivityPage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 }

--- a/src/main/java/task/healthyhabits/resolvers/routines/RoutineQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/routines/RoutineQueryResolver.java
@@ -58,9 +58,23 @@ public class RoutineQueryResolver {
         return routineService.findByIdOrNull(id);
     }
 
-    public record RoutinePage(List<RoutineDTO> content, int totalPages, long totalElements, int size, int number) {
+    public record RoutinePage(
+            List<RoutineDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static RoutinePage from(PageDTO<RoutineDTO> dto) {
-            return new RoutinePage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(), dto.number());
+            return new RoutinePage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 }

--- a/src/main/java/task/healthyhabits/resolvers/users/UserQueryResolver.java
+++ b/src/main/java/task/healthyhabits/resolvers/users/UserQueryResolver.java
@@ -63,15 +63,43 @@ public class UserQueryResolver {
         return UserPage.from(userPageDTO);
     }
 
-   public record UserPage(List<UserDTO> content, int totalPages, long totalElements, int size, int number) {
+    public record UserPage(
+            List<UserDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static UserPage from(PageDTO<UserDTO> dto) {
-            return new UserPage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(), dto.number());
+            return new UserPage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 
-    public record HabitPage(List<HabitDTO> content, int totalPages, long totalElements, int size, int number) {
+    public record HabitPage(
+            List<HabitDTO> content,
+            int totalPages,
+            long totalElements,
+            int size,
+            int number,
+            boolean hasNext,
+            boolean hasPrevious) {
         public static HabitPage from(PageDTO<HabitDTO> dto) {
-            return new HabitPage(dto.content(), dto.totalPages(), dto.totalElements(), dto.size(), dto.number());
+            return new HabitPage(
+                    dto.content(),
+                    dto.totalPages(),
+                    dto.totalElements(),
+                    dto.size(),
+                    dto.number(),
+                    dto.hasNext(),
+                    dto.hasPrevious());
         }
     }
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -123,9 +123,11 @@ type User {
 type RolePage {
   content: [Role!]!
   totalPages: Int!
- totalElements: Long!
+  totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type HabitPage {
@@ -134,6 +136,8 @@ type HabitPage {
   totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type GuidePage {
@@ -142,6 +146,8 @@ type GuidePage {
   totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type RoutineActivityPage {
@@ -150,6 +156,8 @@ type RoutineActivityPage {
   totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type RoutinePage {
@@ -158,6 +166,8 @@ type RoutinePage {
   totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type ProgressLogPage {
@@ -166,6 +176,8 @@ type ProgressLogPage {
   totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type CompletedActivityPage {
@@ -174,6 +186,8 @@ type CompletedActivityPage {
   totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type ReminderPage {
@@ -182,6 +196,8 @@ type ReminderPage {
   totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type UserPage {
@@ -190,6 +206,8 @@ type UserPage {
   totalElements: Long!
   size: Int!
   number: Int!
+  hasNext: Boolean!
+  hasPrevious: Boolean!
 }
 
 type CategoryCount {

--- a/src/test/java/task/healthyhabits/dtosTest/pageDto/PageDTOTest.java
+++ b/src/test/java/task/healthyhabits/dtosTest/pageDto/PageDTOTest.java
@@ -22,5 +22,7 @@ class PageDTOTest {
         assertThat(dto.totalElements()).isEqualTo(page.getTotalElements());
         assertThat(dto.size()).isEqualTo(page.getSize());
         assertThat(dto.number()).isEqualTo(page.getNumber());
+        assertThat(dto.hasNext()).isEqualTo(page.hasNext());
+        assertThat(dto.hasPrevious()).isEqualTo(page.hasPrevious());
     }
 }


### PR DESCRIPTION
## Summary
- extend `PageDTO` with `hasNext` and `hasPrevious` flags populated from Spring Data `Page`
- propagate the new pagination flags through all page records and GraphQL schema types
- update the `PageDTO` unit test to cover the additional metadata

## Testing
- `./mvnw test` *(fails: dependency download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc001f2a8832c8541dffa7c2e9b20